### PR TITLE
add support for `moveOnly` flag

### DIFF
--- a/__tests__/backend/move.test.ts
+++ b/__tests__/backend/move.test.ts
@@ -14,7 +14,7 @@ test("move works correctly", () => {
   mocked(folderManagement).isFolderEmpty_.mockReturnValueOnce(true);
   mocked(moveFolderContents).moveFolderContents_.mockReturnValueOnce();
 
-  expect(move("SRC_ID", "DEST_ID", false, false, false)).toStrictEqual({
+  expect(move("SRC_ID", "DEST_ID", false, false, false, false)).toStrictEqual({
     status: "success",
     response: {
       errors: [],
@@ -42,6 +42,9 @@ test("move works correctly", () => {
     false
   );
   expect(mocked(moveFolderContents).moveFolderContents_.mock.calls[0][2]).toBe(
+    false
+  );
+  expect(mocked(moveFolderContents).moveFolderContents_.mock.calls[0][3]).toBe(
     false
   );
 });
@@ -50,7 +53,7 @@ test("move passes copyComments correctly", () => {
   mocked(folderManagement).isFolderEmpty_.mockReturnValueOnce(true);
   mocked(moveFolderContents).moveFolderContents_.mockReturnValueOnce();
 
-  expect(move("SRC_ID", "DEST_ID", true, false, false)).toStrictEqual({
+  expect(move("SRC_ID", "DEST_ID", false, true, false, false)).toStrictEqual({
     status: "success",
     response: {
       errors: [],
@@ -75,9 +78,12 @@ test("move passes copyComments correctly", () => {
     mocked(moveFolderContents).moveFolderContents_.mock.calls[0][0].path
   ).toStrictEqual([]);
   expect(mocked(moveFolderContents).moveFolderContents_.mock.calls[0][1]).toBe(
-    true
+    false
   );
   expect(mocked(moveFolderContents).moveFolderContents_.mock.calls[0][2]).toBe(
+    true
+  );
+  expect(mocked(moveFolderContents).moveFolderContents_.mock.calls[0][3]).toBe(
     false
   );
 });
@@ -86,7 +92,7 @@ test("move passes mergeFolders correctly", () => {
   mocked(folderManagement).isFolderEmpty_.mockReturnValueOnce(true);
   mocked(moveFolderContents).moveFolderContents_.mockReturnValueOnce();
 
-  expect(move("SRC_ID", "DEST_ID", false, true, false)).toStrictEqual({
+  expect(move("SRC_ID", "DEST_ID", false, false, true, false)).toStrictEqual({
     status: "success",
     response: {
       errors: [],
@@ -114,6 +120,9 @@ test("move passes mergeFolders correctly", () => {
     false
   );
   expect(mocked(moveFolderContents).moveFolderContents_.mock.calls[0][2]).toBe(
+    false
+  );
+  expect(mocked(moveFolderContents).moveFolderContents_.mock.calls[0][3]).toBe(
     true
   );
 });
@@ -124,7 +133,7 @@ test("move detects and reports source matching destination", () => {
   });
   mocked(moveFolderContents).moveFolderContents_.mockReturnValueOnce();
 
-  expect(move("SRC_ID", "SRC_ID", false, false, false)).toStrictEqual({
+  expect(move("SRC_ID", "SRC_ID", false, false, false, false)).toStrictEqual({
     status: "error",
     type: "sourceEqualsDestination",
   });
@@ -141,7 +150,7 @@ test("move fails gracefully on error when checking folder emptiness", () => {
   });
   mocked(moveFolderContents).moveFolderContents_.mockReturnValueOnce();
 
-  expect(move("SRC_ID", "DEST_ID", false, false, false)).toStrictEqual({
+  expect(move("SRC_ID", "DEST_ID", false, false, false, false)).toStrictEqual({
     status: "error",
     type: "DriveAPIError",
   });
@@ -159,7 +168,7 @@ test("move fails gracefully on non-empty destination directory", () => {
   mocked(folderManagement).isFolderEmpty_.mockReturnValueOnce(false);
   mocked(moveFolderContents).moveFolderContents_.mockReturnValueOnce();
 
-  expect(move("SRC_ID", "DEST_ID", false, false, false)).toStrictEqual({
+  expect(move("SRC_ID", "DEST_ID", false, false, false, false)).toStrictEqual({
     status: "error",
     type: "notEmpty",
   });
@@ -177,7 +186,7 @@ test("move works correctly with non-empty override", () => {
   mocked(folderManagement).isFolderEmpty_.mockReturnValueOnce(false);
   mocked(moveFolderContents).moveFolderContents_.mockReturnValueOnce();
 
-  expect(move("SRC_ID", "DEST_ID", false, false, true)).toStrictEqual({
+  expect(move("SRC_ID", "DEST_ID", false, false, false, true)).toStrictEqual({
     status: "success",
     response: {
       errors: [],
@@ -224,7 +233,7 @@ test("move fails gracefully on error while moving", () => {
     .spyOn(console, "error")
     .mockImplementationOnce(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
 
-  expect(move("SRC_ID", "DEST_ID", false, false, false)).toStrictEqual({
+  expect(move("SRC_ID", "DEST_ID", false, false, false, false)).toStrictEqual({
     status: "success",
     response: {
       errors: [error],

--- a/__tests__/backend/move/moveFolderContents.test.ts
+++ b/__tests__/backend/move/moveFolderContents.test.ts
@@ -28,7 +28,7 @@ test("moveFolderContents works correctly with an empty folder", () => {
     new ErrorLogger_()
   );
 
-  moveFolderContents_(context, false, false);
+  moveFolderContents_(context, false, false, false);
 
   expect(listFilesInFolder.mock.calls).toHaveLength(1);
   expect(listFilesInFolder.mock.calls[0][0]).toBe("SRC_ID");
@@ -57,7 +57,7 @@ test("moveFolderContents moves files correctly", () => {
     ["PATH", "TO", "FOLDER"],
     new ErrorLogger_()
   );
-  moveFolderContents_(context, false, false);
+  moveFolderContents_(context, false, false, false);
 
   expect(listFilesInFolder.mock.calls).toHaveLength(1);
   expect(listFilesInFolder.mock.calls[0][0]).toBe("SRC_ID");
@@ -99,7 +99,7 @@ test("moveFolderContents moves folders correctly", () => {
     new ErrorLogger_()
   );
 
-  moveFolderContents_(context, false, false);
+  moveFolderContents_(context, false, false, false);
 
   expect(listFilesInFolder.mock.calls).toHaveLength(3);
   expect(listFilesInFolder.mock.calls[0][0]).toBe("SRC_ID");
@@ -144,7 +144,7 @@ test("moveFolderContents moves files correctly, even when listing folders throws
     ["PATH", "TO", "FOLDER"],
     new ErrorLogger_()
   );
-  moveFolderContents_(context, false, false);
+  moveFolderContents_(context, false, false, false);
 
   expect(listFilesInFolder.mock.calls).toHaveLength(1);
   expect(listFilesInFolder.mock.calls[0][0]).toBe("SRC_ID");
@@ -194,7 +194,7 @@ test("moveFolderContents moves folders correctly, even when listing files throws
     new ErrorLogger_()
   );
 
-  moveFolderContents_(context, false, false);
+  moveFolderContents_(context, false, false, false);
 
   expect(listFilesInFolder.mock.calls).toHaveLength(3);
   expect(listFilesInFolder.mock.calls[0][0]).toBe("SRC_ID");
@@ -251,7 +251,7 @@ test("moveFolderContents handles error when deleting folder gracefully", () => {
     new ErrorLogger_()
   );
 
-  moveFolderContents_(context, false, false);
+  moveFolderContents_(context, false, false, false);
 
   expect(listFilesInFolder.mock.calls).toHaveLength(3);
   expect(listFilesInFolder.mock.calls[0][0]).toBe("SRC_ID");
@@ -302,7 +302,7 @@ test("moveFolderContents passes copyComments correctly", () => {
     new ErrorLogger_()
   );
 
-  moveFolderContents_(context, true, false);
+  moveFolderContents_(context, false, true, false);
 
   expect(listFilesInFolder.mock.calls).toHaveLength(1);
   expect(listFilesInFolder.mock.calls[0][0]).toBe("SRC_ID");
@@ -311,10 +311,10 @@ test("moveFolderContents passes copyComments correctly", () => {
   expect(moveFileFn.mock.calls).toHaveLength(2);
   expect(moveFileFn.mock.calls[0][0].id).toBe("FILE1_ID");
   expect(moveFileFn.mock.calls[0][1]).toStrictEqual(context);
-  expect(moveFileFn.mock.calls[0][2]).toBe(true);
+  expect(moveFileFn.mock.calls[0][3]).toBe(true);
   expect(moveFileFn.mock.calls[1][0].id).toBe("FILE2_ID");
   expect(moveFileFn.mock.calls[1][1]).toStrictEqual(context);
-  expect(moveFileFn.mock.calls[1][2]).toBe(true);
+  expect(moveFileFn.mock.calls[1][3]).toBe(true);
   expect(mocked(context.logger).log.mock.calls).toHaveLength(0);
 });
 
@@ -344,7 +344,7 @@ test("moveFolderContents passes mergeFolders correctly", () => {
     new ErrorLogger_()
   );
 
-  moveFolderContents_(context, false, true);
+  moveFolderContents_(context, false, false, true);
 
   expect(listFilesInFolder.mock.calls).toHaveLength(3);
   expect(listFilesInFolder.mock.calls[0][0]).toBe("SRC_ID");

--- a/src/backend/move.ts
+++ b/src/backend/move.ts
@@ -8,6 +8,7 @@ import type { MoveResponse } from "../interfaces/MoveResponse";
 export function move(
   sourceID: string,
   destinationID: string,
+  moveOnly: boolean,
   copyComments: boolean,
   mergeFolders: boolean,
   notEmptyOverride: boolean
@@ -27,6 +28,7 @@ export function move(
   const logger = new ErrorLogger_();
   moveFolderContents_(
     new MoveContext_(sourceID, destinationID, [], logger),
+    moveOnly,
     copyComments,
     mergeFolders
   );

--- a/src/backend/move/moveFile.ts
+++ b/src/backend/move/moveFile.ts
@@ -35,6 +35,7 @@ function moveFileByCopy_(
 export function moveFile_(
   file: GoogleAppsScript.Drive.Schema.File,
   context: MoveContext_,
+  moveOnly: boolean,
   copyComments: boolean
 ): void {
   if (file.capabilities!.canMoveItemOutOfDrive!) {
@@ -43,5 +44,7 @@ export function moveFile_(
       return;
     } catch (e) {} // eslint-disable-line no-empty
   }
-  moveFileByCopy_(file.id!, file.title!, context, copyComments);
+  if (!moveOnly) {
+    moveFileByCopy_(file.id!, file.title!, context, copyComments);
+  }
 }

--- a/src/backend/move/moveFolderContents.ts
+++ b/src/backend/move/moveFolderContents.ts
@@ -10,6 +10,7 @@ import type { MoveContext_ } from "../utils/MoveContext";
 
 function moveFolderContentsFiles_(
   context: MoveContext_,
+  moveOnly: boolean,
   copyComments: boolean
 ): void {
   const files = context.tryAndLog(() => listFilesInFolder_(context.sourceID));
@@ -17,12 +18,13 @@ function moveFolderContentsFiles_(
     return;
   }
   for (const file of files) {
-    moveFile_(file, context, copyComments);
+    moveFile_(file, context, moveOnly, copyComments);
   }
 }
 
 function moveFolderContentsFolders_(
   context: MoveContext_,
+  moveOnly: boolean,
   copyComments: boolean,
   mergeFolders: boolean
 ): void {
@@ -41,6 +43,7 @@ function moveFolderContentsFolders_(
       );
       moveFolderContents_(
         context.childContext(folder.id!, destinationFolder.id!, folder.title!),
+        moveOnly,
         copyComments,
         mergeFolders
       );
@@ -51,9 +54,10 @@ function moveFolderContentsFolders_(
 
 export function moveFolderContents_(
   context: MoveContext_,
+  moveOnly: boolean,
   copyComments: boolean,
   mergeFolders: boolean
 ): void {
-  moveFolderContentsFiles_(context, copyComments);
-  moveFolderContentsFolders_(context, copyComments, mergeFolders);
+  moveFolderContentsFiles_(context, moveOnly, copyComments);
+  moveFolderContentsFolders_(context, moveOnly, copyComments, mergeFolders);
 }

--- a/src/frontend/App.svelte
+++ b/src/frontend/App.svelte
@@ -18,7 +18,7 @@
 </div>
 <div id="tab">
   {#if currentTab === "introduction"}
-    <Introduction bind:copyComments={copyComments} bind:mergeFolders={mergeFolders}/>
+    <Introduction bind:moveOnly={moveOnly} bind:copyComments={copyComments} bind:mergeFolders={mergeFolders}/>
     <ContinueButton disabled={false} on:next={() => currentTab = "source-selection"}/>
   {:else if currentTab === "source-selection"}
     <FolderSelection step="source-selection" on:error={(event) => {showErrorDialog(event.detail.message)}} bind:path={sourcePath} bind:selected={source}/>
@@ -93,6 +93,7 @@
     currentTab === "destination-selection" ? 3/5 :
     currentTab === "confirmation" ? 4/5 : 0;
 
+  let moveOnly = false;
   let copyComments = true;
   let mergeFolders = true;
   let sourcePath: Array<NamedRecord> = [];
@@ -107,7 +108,7 @@
     google.script.run
       .withSuccessHandler(moveSuccessHandler)
       .withFailureHandler(moveErrorHandler)
-      .move(source!.id, destination!.id, copyComments, mergeFolders, forceNonEmpty);
+      .move(source!.id, destination!.id, moveOnly, copyComments, mergeFolders, forceNonEmpty);
   }
 
   function moveSuccessHandler(response: MoveResponse): void {

--- a/src/frontend/Introduction.svelte
+++ b/src/frontend/Introduction.svelte
@@ -6,6 +6,17 @@
   {$_("steps.introduction.configuration.header")}
 </h5>
 <FormField>
+  <Checkbox bind:checked={moveOnly}/>
+  <span slot="label">
+    <div class="form-heading">
+      {$_("steps.introduction.configuration.moveOnly.title")}
+    </div>
+    {$_("steps.introduction.configuration.moveOnly.description")}
+  </span>
+</FormField>
+<br/>
+<br/>
+<FormField>
   <Checkbox bind:checked={copyComments}/>
   <span slot="label">
     <div class="form-heading">
@@ -35,6 +46,7 @@
 
   import StepHeader from "./StepHeader.svelte";
 
+  export let moveOnly: boolean;
   export let copyComments: boolean;
   export let mergeFolders: boolean;
 </script>

--- a/src/frontend/locales/cs.json
+++ b/src/frontend/locales/cs.json
@@ -5,6 +5,10 @@
 			"welcome": "Vítejte v nástroji \"Shared drive mover\", sloužícím k hromadnému přesouvání souborů a složek v Google Disku. Nástroj je zvlášť užitečný pro přesun z \"Mého Disku\" do Sdílených disků (dříve označovaných jako Týmové disky). V následujících krocích vyberete zdrojovou a cílovou složku. Obsah vybrané zdrojové složky pak bude přesunut do cílové složky. Přesun může trvat déle, buďte prosím trpěliví.",
 			"configuration": {
 				"header": "Nastavení",
+				"moveOnly": {
+					"title": "Pouze přesunout soubory",
+					"description": "Soubory, jichž nejste vlastníkem, se přeskočí místo vytvoření jejich kopie v cílové složce."
+				},
 				"copyComments": {
 					"title": "Kopírovat komentáře při kopírování souborů",
 					"description": "U souborů, jichž nejste vlastníkem, se místo jejich přesunutí vytvoří kopie v cílové složce. Pokud je zaškrtnuta tato volba, komentáře budou vytvořeny pod vaším účtem a původní autor bude označen. Kopírování komentářů může přesun takových souborů zpomalit."

--- a/src/frontend/locales/en.json
+++ b/src/frontend/locales/en.json
@@ -5,6 +5,10 @@
 			"welcome": "Welcome to the Shared drive mover, a tool for moving batches of files and folders across Google Drive. The tool is particularly useful for moving from \"My Drive\" to a Shared drive (formerly known as a Team drive). In the following steps, you will select a source folder and a destination folder. The contents of the selected source folder will then be moved to the destination folder. This process can take some time, so please be patient.",
 			"configuration": {
 				"header": "Configuration",
+				"moveOnly": {
+					"title": "Move files only",
+					"description": "Move only files of which you are the owner, skip other files instead of copying them."
+				},
 				"copyComments": {
 					"title": "Copy comments when copying files",
 					"description": "When moving files of which you are not the owner, instead of moving the file, a copy without comments is created in the destination folder. If this option is checked, the comments will be recreated from your account, with the original commenter tagged. Note that this may slow down the moving of such files."

--- a/src/interfaces/endpoints.d.ts
+++ b/src/interfaces/endpoints.d.ts
@@ -10,6 +10,7 @@ declare namespace google.script {
     move(
       sourceID: string,
       destinationID: string,
+      moveOnly: boolean,
       copyComments: boolean,
       mergeFolders: boolean,
       notEmptyOverride: boolean


### PR DESCRIPTION
Files which can't be moved are skipped instead of being copied when this flag is turned on. This allows to run the process repeatedly in scenarios where we have a folder with a lot of files where only part of them are owned by the person running the "mover" process and is waiting for others to transfer ownership.